### PR TITLE
Recommend minimum version in Gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A PostgreSQL backend for [Refile](https://github.com/elabs/refile).
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'refile-postgres'
+gem 'refile-postgres', '~> 1.4'
 ```
 
 And then execute:


### PR DESCRIPTION
When people, in 2016, start to use refile-postgres on heroku, frequently I see it install version 1.1, which won't work on Heroku.

The solution is to upgrade to 1.4 and go through a somewhat painful upgrade process if they are already on 1.1 with the migrations done.
